### PR TITLE
Add Crystal implementation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,8 @@ jobs:
         uses: dart-lang/setup-dart@v1
       - name: Install DMD
         uses: dlang-community/setup-dlang@v1
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1
       - name: Install Scala
         run: curl -JLO $DEB && sudo dpkg -i scala-2.13.7.deb
         env:

--- a/Crystal/Crystal.cr
+++ b/Crystal/Crystal.cr
@@ -1,0 +1,14 @@
+longest = [] of String
+invalid = /[gkmqvwxzio]/i
+maxlen = 0
+
+File.open("words.txt").each_line do |word|
+    if word.size == maxlen && word !~ invalid
+        longest << word
+    elsif word.size > maxlen && word !~ invalid
+        longest.clear << word
+        maxlen = word.size
+    end
+end
+
+puts longest.join("\n")

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ CPPFLAGS = -std=c++11 -Ofast -march=native
 CSC = mcs
 CSCFLAGS = -o+ -platform:x64
 
+# Crystal
+CRYSTAL = crystal build
+CRYSTALFLAGS = --release
+
 # D
 DC = dmd
 DCFLAGS = -O -release -mcpu=native
@@ -56,11 +60,13 @@ benchmarks = BENCHMARKS.md
 commands = $(shell awk -F[:,] '{printf $$2" "}' t/tests.json)
 
 ## Compile all languages
-all: c cpp cs d dart delphi go java kotlin nim pascal rust scala vala
+all: c cpp crystal cs d dart delphi go java kotlin nim pascal rust scala vala
 
 c: C/C.c; $(CC) $(CFLAGS) -o $(<:.c=.out) $<
 
 cpp: C/C++.cpp; $(CPP) $(CPPFLAGS) -o $(<:.cpp=.out) $<
+
+crystal: Crystal/Crystal.cr; $(CRYSTAL) $(CRYSTALFLAGS) -o $(<:.cr=.out) $<
 
 cs: C/C\#.cs; $(CSC) $(CSCFLAGS) -out:$(<:.cs=.out) $<
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ These are the currently implemented languages:
 * [CMake](CMake/CMake.cmake)
 * [CoffeeScript](JavaScript/CoffeeScript.coffee)
 * [D](D/D.d)
+* [Crystal](Crystal/Crystal.cr)
 * [Dart](Dart/Dart.dart)
 * [Delphi](Pascal/Delphi.pas)
 * [Elixir](Erlang/elixir.ex)

--- a/t/tests.json
+++ b/t/tests.json
@@ -6,6 +6,7 @@
     "CMake": "cmake -P CMake/CMake.cmake 2>&1",
     "C": "C/C.out",
     "CoffeeScript": "coffee JavaScript/CoffeeScript.coffee",
+    "Crystal": "Crystal/Crystal.out",
     "D": "D/D.out",
     "Dart": "Dart/Dart.out",
     "Delphi": "Pascal/Delphi.out",


### PR DESCRIPTION
Pretty much identical to the Ruby implementation.

The only difference is not being able to [initialize an empty array](https://crystal-lang.org/api/latest/Array.html) without a type.

<details><summary>Benchmark Results</summary>

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `Rust/rust.out` | 18.1 ± 0.3 | 17.7 | 18.5 | 1.00 |
| `C/C.out` | 19.9 ± 0.1 | 19.8 | 20.0 | 1.10 ± 0.02 |
| `Go/Go.out` | 22.4 ± 2.6 | 16.8 | 25.0 | 1.24 ± 0.15 |
| `C/C++.out` | 24.7 ± 0.3 | 24.4 | 25.4 | 1.37 ± 0.03 |
| `Crystal/Crystal` | 32.5 ± 0.2 | 32.1 | 32.7 | 1.80 ± 0.03 |
| `Pascal/Pascal.out` | 44.9 ± 0.1 | 44.7 | 45.0 | 2.48 ± 0.04 |
| `php -n PHP/PHP.php` | 74.0 ± 0.7 | 73.0 | 74.7 | 4.10 ± 0.07 |
| `C/Vala.out` | 78.7 ± 0.2 | 78.4 | 79.0 | 4.36 ± 0.07 |
| `Dart/Dart.out` | 80.1 ± 1.0 | 78.7 | 81.8 | 4.44 ± 0.08 |
| `Nim/Nim.out` | 84.0 ± 0.5 | 83.5 | 85.0 | 4.65 ± 0.07 |
| `D/D.out` | 87.5 ± 1.2 | 86.5 | 89.9 | 4.85 ± 0.10 |
| `Pascal/Delphi.out` | 97.6 ± 0.5 | 96.8 | 98.2 | 5.41 ± 0.08 |
| `node JavaScript/JavaScript.js` | 114.1 ± 1.4 | 112.9 | 116.9 | 6.32 ± 0.12 |
| `mono C/C#.out` | 116.1 ± 0.7 | 114.8 | 116.9 | 6.43 ± 0.10 |
| `python3 Python/Python.py` | 138.3 ± 4.8 | 133.3 | 147.8 | 7.66 ± 0.29 |
| `ruby Ruby/Ruby.rb` | 138.4 ± 0.6 | 137.6 | 139.4 | 7.66 ± 0.12 |
| `awk -f Awk/Awk.awk` | 146.0 ± 0.6 | 145.4 | 146.6 | 8.08 ± 0.12 |
| `perl Perl/Perl.pl` | 151.9 ± 4.8 | 149.3 | 162.7 | 8.41 ± 0.29 |
| `lsc JavaScript/LiveScript.ls` | 186.4 ± 0.9 | 185.0 | 187.4 | 10.32 ± 0.16 |
| `java -cp Java Java7SegmentDisplays` | 234.6 ± 37.4 | 205.2 | 315.3 | 12.99 ± 2.08 |
| `lua5.3 Lua/Lua.lua` | 260.3 ± 1.1 | 259.2 | 262.4 | 14.41 ± 0.22 |
| `gawk -f Awk/Gawk.awk` | 293.3 ± 1.5 | 291.5 | 295.2 | 16.24 ± 0.25 |
| `julia Julia/Julia.jl` | 356.4 ± 6.7 | 349.9 | 369.4 | 19.74 ± 0.47 |
| `kotlin -cp Java Kotlin7SegmentDisplays` | 357.6 ± 13.1 | 345.5 | 379.4 | 19.80 ± 0.78 |
| `ts-node --skip-project -T JavaScript/TypeScript.ts` | 382.0 ± 1.4 | 380.1 | 383.7 | 21.15 ± 0.32 |
| `escript -c Erlang/erlang.erl` | 396.6 ± 3.7 | 392.3 | 403.6 | 21.96 ± 0.38 |
| `elixir Erlang/elixir.ex` | 555.6 ± 15.5 | 536.6 | 575.2 | 30.76 ± 0.97 |
| `coffee JavaScript/CoffeeScript.coffee` | 571.8 ± 1.6 | 569.2 | 573.9 | 31.66 ± 0.47 |
| `sqlite3 /tmp/7SegmentDisplays.db <SQL/SQLite.sql` | 619.7 ± 2.1 | 616.9 | 623.0 | 34.32 ± 0.52 |
| `psql -d 7SegmentDisplays -qtAX -f SQL/PostgreSQL.sql` | 642.6 ± 0.9 | 641.5 | 644.1 | 35.58 ± 0.53 |
| `scala -cp Java Scala7SegmentDisplays` | 708.6 ± 34.1 | 670.6 | 777.7 | 39.24 ± 1.97 |
| `Rscript --vanilla R/R.r` | 751.9 ± 9.6 | 738.6 | 765.2 | 41.63 ± 0.81 |
| `groovy Java/Groovy.groovy 2>/dev/null` | 977.4 ± 46.7 | 938.6 | 1072.6 | 54.12 ± 2.71 |
| `mysql 7SegmentDisplays -Ns <SQL/MySQL.sql` | 1874.5 ± 4.4 | 1866.0 | 1879.9 | 103.80 ± 1.55 |
| `zsh -f Shell/Zsh.sh` | 3165.2 ± 19.4 | 3127.7 | 3185.8 | 175.27 ± 2.79 |
| `bash --noprofile --norc Shell/Bash.sh` | 5154.2 ± 113.8 | 4978.6 | 5300.9 | 285.40 ± 7.57 |
| `perl6 Perl/Perl6.p6` | 5508.4 ± 89.6 | 5406.2 | 5653.9 | 305.02 ± 6.69 |
| `cmake -P CMake/CMake.cmake 2>&1` | 8114.6 ± 100.8 | 8022.4 | 8330.9 | 449.33 ± 8.65 |
</details>