### PR TITLE
Fixed 404 on checking C# implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ These are the currently implemented languages:
 * [Bash](Shell/Bash.sh)
 * [C](C/C.c)
 * [C++](C/C++.cpp)
-* [C#](C/C#.cs)
+* [C#](CSharp/C%23.cs)
 * [CMake](CMake/CMake.cmake)
 * [CoffeeScript](JavaScript/CoffeeScript.coffee)
 * [Crystal](Crystal/Crystal.cr)


### PR DESCRIPTION
You would need to use the URL encoding of `#` (`%23`) to avoid that character being interpreted as a fragment identifier (also, the subdirectory needed to be changed from `C` to `CSharp`, but I suppose you just forgot to include that in 369c8bd)